### PR TITLE
Fix mixed Chinese and English punctuation

### DIFF
--- a/notebook/C3/1.从GGUF直接导入/main.ipynb
+++ b/notebook/C3/1.从GGUF直接导入/main.ipynb
@@ -27,7 +27,7 @@
    "outputs": [],
    "source": [
     "# 3. 终端内运行下列脚本运行模型\n",
-    "！ollama run mymodel"
+    "!ollama run mymodel"
    ]
   }
  ],


### PR DESCRIPTION
The repository contains mixed use of Chinese (full-width) and English (half-width) punctuation in notebooks. 
This PR:
- Replaces inconsistent punctuation to match the language context (use full-width punctuation in Chinese text).
- No functional code changes.