### PR TITLE
Update uvicorn dependency to include standard extras

### DIFF
--- a/notebook/C6/fastapi_chat_app/requirements.txt
+++ b/notebook/C6/fastapi_chat_app/requirements.txt
@@ -1,3 +1,3 @@
 fastapi
-uvicorn
+uvicorn[standard]
 ollama


### PR DESCRIPTION
change uvicorn to uvicorn[standard] in requirements

picture for reference:
<img width="1432" height="67" alt="image" src="https://github.com/user-attachments/assets/a0a3ebf7-a2fd-467a-a6ac-7bc310deff59" />
